### PR TITLE
using-mocks: avoid exception when not using and document an edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,10 @@ Our most useful function.
 
 It creates the files and, optionally, can mock VSCode's functions. It receives a callback and, when it's finished, clear the files and mocks.
 
+#### Files
+
 You can create as many files as needed, and their URI is sent to the callback:
+
 ```js
 using(
   {
@@ -239,7 +242,9 @@ using(
 )
 ```
 
-Unfortunately, there are some VSCode features in which we can't manipulate, such as the `window.showQuickPick`. But no worries! We can easily mock it:
+#### Mocks
+
+There are some VSCode features in which we can't manipulate, such as the `window.showQuickPick`. But no worries! We can easily mock it:
 
 ```js
 using(
@@ -258,6 +263,32 @@ using(
 ```
 
 Now, if the extension calls `window.showQuickPick` it'll return `Promise<'My Option'>`.
+
+But there is a rule to use mocks: You should ensure that the extension is initialized. For example, let's say that your extension is initialized only when there is a `.ml` file in the workspace:
+
+```json
+"activationEvents": [
+  "workspaceContains:**/*.ml"
+]
+```
+
+So you should run the tests using workspace and create at least one `.ml` file:
+
+```js
+using(
+  {
+    files: {
+      'main.ml': 'let hello () = print_endline "hey there"',
+    },
+    mocks: {
+      'window.showQuickPick': async () => 'My Option',
+    },
+  },
+  async (mapFilenameToUri) => {
+
+  }
+)
+```
 
 ### `dedent`
 

--- a/src/usingMocks.ts
+++ b/src/usingMocks.ts
@@ -1,16 +1,28 @@
+import dedent from 'dedent-js'
 import keys from 'lodash/keys'
 import set from 'lodash/set'
 import get from 'lodash/get'
+import size from 'lodash/size'
 
 type Mocks = { [key: string]: unknown }
 
 const vscodeOriginalProperties: Mocks = {}
 
 const usingVscodeMocks = async (mocks: Mocks, closure: () => Promise<void>) => {
+  if (size(mocks) === 0) {
+    await closure()
+    return
+  }
+
   const globalVscode = globalThis.extensionVscode
 
   if (globalVscode === undefined) {
-    throw new Error('Missing "global.extensionVscode". Check the setup documentation for jest-environment-vscode-extension')
+    throw new Error(dedent(`
+      Missing "global.extensionVscode". We can't mock VSCode.
+      It can happen because of two reasons:
+      - the extension was not initialized
+      - wrong jest-environment-vscode-extension setup
+    `))
   }
 
   const mocksPath = keys(mocks)


### PR DESCRIPTION
If the extension isn't ​initialized, there is no `globalThis.extensionVscode`

Then we can avoid raising an exception if we are not mocking anything and document this edge case