### PR TITLE
General fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Running by VSCode is great for development since it's quick and can use breakpoi
 1 - On `package.json`, add the following within the `scripts` object:
 
 ```json
-"tests:ci:no-workspace": "vscode-electron-starter no-workspace $INIT_CWD insiders out/tests/no-workspace",
-"tests:ci:with-workspace": "vscode-electron-starter with-workspace $INIT_CWD insiders out/tests/with-workspace"
+"tests:ci:no-workspace": "vscode-electron-starter no-workspace insiders out/tests/no-workspace",
+"tests:ci:with-workspace": "vscode-electron-starter with-workspace insiders out/tests/with-workspace"
 ```
 
 The penultimate parameter is the VSCode version being used. You can use `stable`, `insiders`, or a version number (e.g., `1.32.0`). The last parameter is the path of the test.

--- a/cli/vscode-electron-starter.js
+++ b/cli/vscode-electron-starter.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const path = require('path')
+const fs = require('fs')
 const os = require('os')
 const { runTests } = require('@vscode/test-electron')
 const insertMonkeyPatchAllowMocks = require('./insert-monkey-patch-allow-mocks')
@@ -44,6 +45,13 @@ const runWithWorkspace = async ({ extensionDevelopmentPath, extensionTestsPath, 
 	})
 }
 
+const recreateTestWorkspaceFolder = (extensionDevelopmentPath) => {
+  const testWorkspacePath = path.resolve(extensionDevelopmentPath, "test-workspace")
+
+  fs.rmSync(testWorkspacePath, { force: true, recursive: true })
+  fs.mkdirSync(testWorkspacePath, { recursive: true })
+}
+
 const start = async () => {
   const [testScenery, version, testsPath] = [process.argv[2], process.argv[3], process.argv[4]]
   const extensionDevelopmentPath = process.cwd()
@@ -53,6 +61,7 @@ const start = async () => {
     'node_modules/.bin/vscode-tests-runner'
   )
 
+  recreateTestWorkspaceFolder(extensionDevelopmentPath)
   insertMonkeyPatchAllowMocks(extensionDevelopmentPath)
   
 	try {

--- a/cli/vscode-electron-starter.js
+++ b/cli/vscode-electron-starter.js
@@ -1,14 +1,26 @@
 #!/usr/bin/env node
 const path = require('path')
+const os = require('os')
 const { runTests } = require('@vscode/test-electron')
 const insertMonkeyPatchAllowMocks = require('./insert-monkey-patch-allow-mocks')
 const dropMonkeyPatchAllowMocks = require('./drop-monkey-patch-allow-mocks')
+
+const getRandomTempDiretory = () => {
+  const timestamp = Date.now()
+  const folderName = `test-extension-${timestamp}`
+  const tempPath = path.resolve(os.tmpdir(), folderName)
+
+  return tempPath
+}
 
 const runNoWorkspace = async ({ extensionDevelopmentPath, extensionTestsPath, version, testsPath }) => {
 	await runTests({
     version,
 		extensionDevelopmentPath,
 		extensionTestsPath,
+    launchArgs: [
+      `--user-data-dir=${getRandomTempDiretory()}`,
+    ],
 		extensionTestsEnv: {
 			VSCODE_TESTS_PATH: path.resolve(extensionDevelopmentPath, testsPath),
 		},
@@ -24,6 +36,7 @@ const runWithWorkspace = async ({ extensionDevelopmentPath, extensionTestsPath, 
 		extensionTestsPath,
     launchArgs: [
       testWorkspace,
+      `--user-data-dir=${getRandomTempDiretory()}`,
     ],
 		extensionTestsEnv: {
 			VSCODE_TESTS_PATH: path.resolve(extensionDevelopmentPath, testsPath),

--- a/cli/vscode-electron-starter.js
+++ b/cli/vscode-electron-starter.js
@@ -32,12 +32,8 @@ const runWithWorkspace = async ({ extensionDevelopmentPath, extensionTestsPath, 
 }
 
 const start = async () => {
-  const [
-    testScenery,
-    extensionDevelopmentPath,
-    version,
-    testsPath,
-  ] = [process.argv[2], process.argv[3], process.argv[4], process.argv[5]]
+  const [testScenery, version, testsPath] = [process.argv[2], process.argv[3], process.argv[4]]
+  const extensionDevelopmentPath = process.cwd()
 
   const extensionTestsPath = path.resolve(
     extensionDevelopmentPath,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-vscode-extension",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-vscode-extension",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "publisher": "macabeus",
   "repository": "https://github.com/macabeus/jest-environment-vscode",

--- a/src/usingFiles.ts
+++ b/src/usingFiles.ts
@@ -1,5 +1,6 @@
 import { commands, Position, Uri, workspace, WorkspaceEdit } from 'vscode'
 import * as path from 'path'
+import { readdirSync, rmSync } from 'fs'
 import mapValues from 'lodash/mapValues'
 
 type UsingFiles = <Files extends { [filename: string]: string }>(
@@ -10,7 +11,16 @@ type UsingFiles = <Files extends { [filename: string]: string }>(
   }) => Promise<void>
 ) => Promise<void>
 
+const removeWorkspaceTestContent = (workspacePath: string) => {
+  readdirSync(workspacePath).forEach((filename) => {
+    const fullPath = path.resolve(workspacePath, filename)
+    rmSync(fullPath, { force: true, recursive: true })
+  })
+}
+
 const usingFiles: UsingFiles = async (workspacePath, files, closure) => {
+  removeWorkspaceTestContent(workspacePath)
+
   const mapFilenameToUri = mapValues(
     files,
     (_content, filename) => Uri.file(path.join(workspacePath, filename))


### PR DESCRIPTION
- Drop second parameter on `vscode-electron-starter`. It's useful for Windows support
- Add flag `user-data-dir` when calling vscode tests. It's useful for avoiding errors if the extension name is too big
- Remove all `workspace-test` content when calling `usingFiles` and CLI. It's useful to avoid leftovers from a previous failed test or a previous run