### PR TITLE
using-files: send `TextDocument` instead of `Uri`

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ describe('#Definition', () => {
           console.log(x)
         `),
       }},
-      async (mapFileToUri) => {
+      async (mapFileToDoc) => {
         // on the file `index.js`, take the definitions at 1:12 (the `x` within the `console.log`)
-        const definitions = await take.definitions(mapFileToUri['index.js'], new Position(1, 12))
+        const definitions = await take.definitions(mapFileToDoc['index.js'], new Position(1, 12))
 
         // assert that it's as the expected
         expect(definitions).toHaveLength(1)
@@ -244,7 +244,7 @@ It creates the files and, optionally, can mock VSCode's functions. It receives a
 
 #### Files
 
-You can create as many files as needed, and their URI is sent to the callback:
+You can create as many files as needed, and their [`TextDocument`](https://code.visualstudio.com/api/references/vscode-api#TextDocument) is sent to the callback:
 
 ```js
 using(
@@ -255,10 +255,10 @@ using(
       'bar.js': '2;',
     },
   },
-  async (mapFilenameToUri) => {
-    mapFilenameToUri['index.js'] // URI
-    mapFilenameToUri['foo.js']   // URI
-    mapFilenameToUri['bar.js']   // URI
+  async (mapFileToDoc) => {
+    mapFileToDoc['index.js'] // TextDocument
+    mapFileToDoc['foo.js']   // TextDocument
+    mapFileToDoc['bar.js']   // TextDocument
   }
 )
 ```
@@ -277,7 +277,7 @@ using(
       'window.showQuickPick': async () => 'My Option',
     },
   },
-  async (mapFilenameToUri) => {
+  async (mapFileToDoc) => {
 
   }
 )
@@ -305,7 +305,7 @@ using(
       'window.showQuickPick': async () => 'My Option',
     },
   },
-  async (mapFilenameToUri) => {
+  async (mapFileToDoc) => {
 
   }
 )
@@ -324,7 +324,7 @@ For example, if you want to open and show a document, you should do:
 ```js
 const { workspace, window } = vscode
 
-const doc = await workspace.openTextDocument(mapFileToUri['index.js'])
+const doc = await workspace.openTextDocument(mapFileToDoc['index.js'])
 await window.showTextDocument(doc)
 ```
 
@@ -352,9 +352,9 @@ It exposes a helper function to wait for something.
 For example, if your extension takes time to initialize, it can be useful:
 
 ```js
-const waitForDocumentSymbols = async (uri, position) => {
+const waitForDocumentSymbols = async (doc, position) => {
   return await waitFor(async () => {
-    const hovers = await take.hovers(uri, position)
+    const hovers = await take.hovers(doc, position)
     expect(hovers).toHaveLength(1)
     return hovers
   })
@@ -368,8 +368,8 @@ describe("#Document Symbol", () => {
           'main.ml': 'let hello () = print_endline "hey there"',
         },
       },
-      async (mapFilenameToUri) => {
-        const symbols = await waitForDocumentSymbols(mapFilenameToUri['main.ml'])
+      async (mapFileToDoc) => {
+        const symbols = await waitForDocumentSymbols(mapFileToDoc['main.ml'])
 
         expect(symbols[0]).toMatchObject({
             name: 'hello',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jest-environment-vscode-extension",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-environment-vscode-extension",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@vscode/test-electron": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-vscode-extension",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "publisher": "macabeus",
   "repository": "https://github.com/macabeus/jest-environment-vscode",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import NodeEnvironment from 'jest-environment-node'
 import type { Config } from '@jest/types'
-import type { Uri } from 'vscode'
+import type { TextDocument } from 'vscode'
 import * as vscode from 'vscode'
 import * as path from 'path'
 import dedent from 'dedent-js'
@@ -17,7 +17,7 @@ type Using = <Files extends { [filename: string]: string }>(
     }
   },
   closure: (mapFileToUri: {
-    [filename in keyof Files]: Uri
+    [filename in keyof Files]: TextDocument
   }) => Promise<void>
 ) => Promise<void>
 
@@ -31,7 +31,7 @@ class VsCodeExtensionEnvironment extends NodeEnvironment {
       usingFiles(
         workspacePath,
         files,
-        (mapFilenameToUri) => usingMocks(mocks, () => closure(mapFilenameToUri))
+        (mapFileToDoc) => usingMocks(mocks, () => closure(mapFileToDoc))
       )
 
     this.global.vscode = vscode

--- a/src/take.ts
+++ b/src/take.ts
@@ -1,10 +1,9 @@
-import { window, commands, CodeAction, workspace, Uri, Range, Hover, Position, SymbolInformation, Location, LocationLink } from 'vscode'
+import { window, commands, CodeAction, workspace, Uri, Range, Hover, Position, SymbolInformation, Location, LocationLink, TextDocument } from 'vscode'
 
-const codeActions = async (uri: Uri, range: Range) => {
-  const doc = await workspace.openTextDocument(uri)
+const codeActions = async (doc: TextDocument, range: Range) => {
   await window.showTextDocument(doc)
 
-  const rawCodeActions = await commands.executeCommand('vscode.executeCodeActionProvider', uri, range) as CodeAction[]
+  const rawCodeActions = await commands.executeCommand('vscode.executeCodeActionProvider', doc.uri, range) as CodeAction[]
 
   const codeActions = rawCodeActions.reduce((acc, codeAction) => {
     const { command: codeActionCommand } = codeAction
@@ -20,37 +19,33 @@ const codeActions = async (uri: Uri, range: Range) => {
   return codeActions
 }
 
-const definitions = async (uri: Uri, position: Position) => {
-  const doc = await workspace.openTextDocument(uri)
+const definitions = async (doc: TextDocument, position: Position) => {
   await window.showTextDocument(doc)
 
-  const definitions = await commands.executeCommand('vscode.executeDefinitionProvider', uri, position) as Array<Location | LocationLink>
+  const definitions = await commands.executeCommand('vscode.executeDefinitionProvider', doc.uri, position) as Array<Location | LocationLink>
 
   return definitions
 }
 
-const hovers = async (uri: Uri, position: Position) => {
-  const doc = await workspace.openTextDocument(uri)
+const hovers = async (doc: TextDocument, position: Position) => {
   await window.showTextDocument(doc)
 
-  const hovers = await commands.executeCommand('vscode.executeHoverProvider', uri, position) as Hover[]
+  const hovers = await commands.executeCommand('vscode.executeHoverProvider', doc.uri, position) as Hover[]
 
   const hoversContent = hovers.flatMap((hover) => hover.contents.map(content => (content as { value: string }).value))
 
   return hoversContent
 }
 
-const documentSymbols = async (uri: Uri) => {
-  const doc = await workspace.openTextDocument(uri)
+const documentSymbols = async (doc: TextDocument) => {
   await window.showTextDocument(doc)
 
-  const documentSymbols = await commands.executeCommand('vscode.executeDocumentSymbolProvider', uri) as SymbolInformation[]
+  const documentSymbols = await commands.executeCommand('vscode.executeDocumentSymbolProvider', doc.uri) as SymbolInformation[]
 
   return documentSymbols
 }
 
-const documentText = async (uri: Uri) => {
-  const doc = await workspace.openTextDocument(uri)
+const documentText = async (doc: TextDocument) => {
   const textDocument = await window.showTextDocument(doc)
   const text = textDocument.document.getText()
 


### PR DESCRIPTION
A new VS Code version broke this library since sometimes commands like `vscode.executeCodeActionProvider` can be run before the file is ready for that.

Then, this PR adds a warm-up step at the end of `usingFiles`, to ensure that all files are ready.

In addition to that, now the callback for `usingFiles` receives `TextDocument` instead of `Uri` (since all files are already open)
